### PR TITLE
chore(pkg): declare top-level "svelte" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"**/*.css"
 	],
 	"type": "module",
+	"svelte": "./dist/svelte/index.js",
 	"exports": {
 		"./svelte": {
 			"types": "./dist/svelte/index.d.ts",


### PR DESCRIPTION
## Summary

Follow-up to #25 / #28 with a one-line fix.

Declares a top-level `"svelte"` field in `package.json` so SvelteKit auto-adds the package to `ssr.noExternal` and bundles it with the consumer's svelte instance during SSR.

Without this, the package is externalized at runtime and its `import { setContext } from 'svelte'` resolves to a separate svelte module instance from the consumer's compiled `.svelte` chunks. Module-scoped `ssr_context` is split between the two copies, so any context API call (here via `createSvelteAuthClient` -> `resolveConvexClient` -> `setupConvex` -> `setConvexClientContext` -> `setContext`) throws `lifecycle_outside_component` during prerender even though the call is inside a `$$renderer.component()` callback.

Path mirrors the existing `./svelte` export entry: `./dist/svelte/index.js`.

Resolves: #28
See also: #25

## References

- SvelteKit auto-bundling Svelte component libraries: https://github.com/sveltejs/kit/pull/1148
- Auto-detect via `svelte` field: https://github.com/sveltejs/kit/issues/904
- Vite `ssr.noExternal` docs: https://vite.dev/config/ssr-options.html#ssr-noexternal
- SvelteKit packaging docs: https://svelte.dev/docs/kit/packaging

## Test plan

- [ ] CI green
- [ ] After publish, consumer can drop `'@mmailaender/convex-better-auth-svelte'` from `ssr.noExternal` in their `vite.config.ts` without prerender regressions