### PR TITLE
fix: retry transient HTTP errors when fetching the Convex token

### DIFF
--- a/.changeset/thick-hats-repair.md
+++ b/.changeset/thick-hats-repair.md
@@ -1,0 +1,5 @@
+---
+'@mmailaender/convex-better-auth-svelte': patch
+---
+
+Retry transient HTTP errors (5xx, 408, 429) when fetching the Convex token instead of treating them as a sign-out. The Better Auth client resolves with `{ data, error }` on HTTP error statuses rather than throwing, so a single 502 while the server restarts during a deploy used to be reported as "no token" and flipped `useAuth().isAuthenticated` to false with no recovery until a full reload. Only definitive 4xx responses (401/403) are now treated as an expired or revoked session.

--- a/src/lib/svelte/client.svelte.ts
+++ b/src/lib/svelte/client.svelte.ts
@@ -10,6 +10,8 @@ import type { BetterAuthClientOptions, BetterAuthClientPlugin } from 'better-aut
 import type { createAuthClient } from 'better-auth/svelte';
 import type { crossDomainClient, convexClient } from '@convex-dev/better-auth/client/plugins';
 
+import { fetchTokenBrowser } from './fetch-token.js';
+
 /* -------------------------------------------------------------------------- */
 /*                                  Types                                     */
 /* -------------------------------------------------------------------------- */
@@ -511,51 +513,6 @@ const makeFetchAccessTokenExternal = (
 			return null;
 		}
 	};
-};
-
-/* -------------------------------------------------------------------------- */
-/*                          Token helpers                                     */
-/* -------------------------------------------------------------------------- */
-
-const fetchTokenBrowser = async (
-	authClient: AuthClient,
-	logVerbose: (message: string) => void
-): Promise<string | null> => {
-	const initialBackoff = 100;
-	const maxBackoff = 1000;
-	let retries = 0;
-
-	const nextBackoff = () => {
-		const baseBackoff = initialBackoff * Math.pow(2, retries);
-		retries += 1;
-		const actualBackoff = Math.min(baseBackoff, maxBackoff);
-		const jitter = actualBackoff * (Math.random() - 0.5);
-		return actualBackoff + jitter;
-	};
-
-	const fetchWithRetry = async (): Promise<string | null> => {
-		try {
-			const { data } = await authClient.convex.token();
-			return data?.token || null;
-		} catch (e) {
-			if (!isNetworkError(e)) {
-				// Non-network errors (e.g. 401/403 after session expiry) mean
-				// the session is gone — return null instead of throwing.
-				logVerbose(`fetchToken failed with non-network error: ${e}`);
-				return null;
-			}
-			if (retries > 10) {
-				logVerbose(`fetchToken failed with network error, giving up`);
-				throw e;
-			}
-			const backoff = nextBackoff();
-			logVerbose(`fetchToken failed with network error, attempting retrying in ${backoff}ms`);
-			await new Promise((resolve) => setTimeout(resolve, backoff));
-			return fetchWithRetry();
-		}
-	};
-
-	return fetchWithRetry();
 };
 
 // Handle one-time token verification (equivalent to useEffect)

--- a/src/lib/svelte/fetch-token.spec.ts
+++ b/src/lib/svelte/fetch-token.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { fetchTokenBrowser, type ConvexTokenClient } from './fetch-token.js';
+
+// ---------------------------------------------------------------------------
+// fetchTokenBrowser classifies failures of authClient.convex.token():
+//
+// - The Better Auth client resolves with { data, error } on HTTP error
+//   statuses (throw is opt-in), so HTTP failures arrive as `error`, not as
+//   thrown exceptions.
+// - Definitive 4xx (401/403) mean the session is gone → return null so the
+//   Convex AuthenticationManager reports unauthenticated.
+// - Transient failures (5xx, 408, 429, network errors) are retried with
+//   backoff. Returning null for those would sign the user out of live
+//   queries after a single failed refresh, e.g. a 502 during a deploy.
+// ---------------------------------------------------------------------------
+
+const noop = () => {};
+
+type TokenResult = Awaited<ReturnType<ConvexTokenClient['convex']['token']>>;
+
+/** Builds a client whose token() call plays back the given results in order. */
+function clientWithResults(results: (TokenResult | Error)[]): {
+	client: ConvexTokenClient;
+	token: ReturnType<typeof vi.fn>;
+} {
+	let call = 0;
+	const token = vi.fn(async (): Promise<TokenResult> => {
+		const result = results[Math.min(call, results.length - 1)];
+		call += 1;
+		if (result instanceof Error) throw result;
+		return result;
+	});
+	return { client: { convex: { token } }, token };
+}
+
+const ok = (token: string): TokenResult => ({ data: { token }, error: null });
+const httpError = (status: number): TokenResult => ({ data: null, error: { status } });
+
+/** TypeError('Failed to fetch') is what is-network-error recognizes. */
+const networkError = () => new TypeError('Failed to fetch');
+
+async function runWithTimers<T>(promise: Promise<T>): Promise<T> {
+	// Flush the backoff timers until the promise settles.
+	let settled = false;
+	const tracked = promise.finally(() => {
+		settled = true;
+	});
+	// Prevent unhandled rejection warnings while timers advance.
+	tracked.catch(noop);
+	while (!settled) {
+		await vi.advanceTimersByTimeAsync(2000);
+	}
+	return tracked;
+}
+
+describe('fetchTokenBrowser', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('returns the token on first success', async () => {
+		const { client, token } = clientWithResults([ok('jwt-1')]);
+		await expect(fetchTokenBrowser(client, noop)).resolves.toBe('jwt-1');
+		expect(token).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns null when the response has no token and no error', async () => {
+		const { client, token } = clientWithResults([{ data: null, error: null }]);
+		await expect(fetchTokenBrowser(client, noop)).resolves.toBeNull();
+		expect(token).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns null without retrying on 401 (session gone)', async () => {
+		const { client, token } = clientWithResults([httpError(401)]);
+		await expect(fetchTokenBrowser(client, noop)).resolves.toBeNull();
+		expect(token).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns null without retrying on 403 (session revoked)', async () => {
+		const { client, token } = clientWithResults([httpError(403)]);
+		await expect(fetchTokenBrowser(client, noop)).resolves.toBeNull();
+		expect(token).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns null without retrying on other definitive 4xx (misconfiguration)', async () => {
+		const { client, token } = clientWithResults([httpError(404)]);
+		await expect(fetchTokenBrowser(client, noop)).resolves.toBeNull();
+		expect(token).toHaveBeenCalledTimes(1);
+	});
+
+	it('retries a 502 during a deploy and recovers', async () => {
+		const { client, token } = clientWithResults([httpError(502), httpError(502), ok('jwt-2')]);
+		await expect(runWithTimers(fetchTokenBrowser(client, noop))).resolves.toBe('jwt-2');
+		expect(token).toHaveBeenCalledTimes(3);
+	});
+
+	it('retries 500, 429 and 408 responses', async () => {
+		for (const status of [500, 429, 408]) {
+			const { client, token } = clientWithResults([httpError(status), ok('jwt-3')]);
+			await expect(runWithTimers(fetchTokenBrowser(client, noop))).resolves.toBe('jwt-3');
+			expect(token).toHaveBeenCalledTimes(2);
+		}
+	});
+
+	it('retries when the error carries no status', async () => {
+		const { client, token } = clientWithResults([{ data: null, error: {} }, ok('jwt-4')]);
+		await expect(runWithTimers(fetchTokenBrowser(client, noop))).resolves.toBe('jwt-4');
+		expect(token).toHaveBeenCalledTimes(2);
+	});
+
+	it('gives up with null after persistent server errors', async () => {
+		const { client, token } = clientWithResults([httpError(503)]);
+		await expect(runWithTimers(fetchTokenBrowser(client, noop))).resolves.toBeNull();
+		expect(token.mock.calls.length).toBeGreaterThan(10);
+	});
+
+	it('retries network errors and recovers (existing behavior)', async () => {
+		const { client, token } = clientWithResults([networkError(), ok('jwt-5')]);
+		await expect(runWithTimers(fetchTokenBrowser(client, noop))).resolves.toBe('jwt-5');
+		expect(token).toHaveBeenCalledTimes(2);
+	});
+
+	it('throws after persistent network errors (existing behavior)', async () => {
+		const { client } = clientWithResults([networkError()]);
+		await expect(runWithTimers(fetchTokenBrowser(client, noop))).rejects.toThrow('Failed to fetch');
+	});
+
+	it('returns null on non-network exceptions (existing behavior)', async () => {
+		const { client, token } = clientWithResults([new Error('boom')]);
+		await expect(fetchTokenBrowser(client, noop)).resolves.toBeNull();
+		expect(token).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/svelte/fetch-token.ts
+++ b/src/lib/svelte/fetch-token.ts
@@ -1,0 +1,97 @@
+import isNetworkError from 'is-network-error';
+
+/**
+ * Minimal structural view of the Better Auth client used by
+ * {@link fetchTokenBrowser}. The real client's `convex.token()` resolves with
+ * `{ data, error }` and only throws on network-level failures (the Better Auth
+ * client does not use `throw: true`).
+ */
+export type ConvexTokenClient = {
+	convex: {
+		token: () => Promise<{
+			data: { token?: string | null } | null;
+			error: { status?: number } | null;
+		}>;
+	};
+};
+
+/**
+ * HTTP statuses that indicate a transient server-side failure (a deploy or
+ * restart behind a proxy, a timeout, a rate limit) rather than an invalidated
+ * session. These are retried with the same backoff as network errors. A
+ * missing status is treated as transient because it carries no evidence that
+ * the session is gone.
+ */
+const isTransientStatus = (status: number | undefined): boolean =>
+	status === undefined || status === 408 || status === 429 || status >= 500;
+
+/**
+ * Fetch a Convex JWT via the Better Auth client, retrying transient failures.
+ *
+ * Returning `null` tells the Convex `AuthenticationManager` that the user is
+ * definitively unauthenticated; it reports `onChange(false)` and stops without
+ * retrying. So `null` must only be returned when the session is actually gone
+ * (401/403 and other definitive 4xx), never for a transient server error,
+ * otherwise a single 502 during a deploy signs the user out of live queries
+ * until a full reload.
+ */
+export const fetchTokenBrowser = async (
+	authClient: ConvexTokenClient,
+	logVerbose: (message: string) => void
+): Promise<string | null> => {
+	const initialBackoff = 100;
+	const maxBackoff = 1000;
+	let retries = 0;
+
+	const nextBackoff = () => {
+		const baseBackoff = initialBackoff * Math.pow(2, retries);
+		retries += 1;
+		const actualBackoff = Math.min(baseBackoff, maxBackoff);
+		const jitter = actualBackoff * (Math.random() - 0.5);
+		return actualBackoff + jitter;
+	};
+
+	const retryAfterBackoff = async (failure: string): Promise<string | null> => {
+		const backoff = nextBackoff();
+		logVerbose(`fetchToken failed with ${failure}, retrying in ${backoff}ms`);
+		await new Promise((resolve) => setTimeout(resolve, backoff));
+		return fetchWithRetry();
+	};
+
+	const fetchWithRetry = async (): Promise<string | null> => {
+		let result: Awaited<ReturnType<ConvexTokenClient['convex']['token']>>;
+		try {
+			result = await authClient.convex.token();
+		} catch (e) {
+			if (!isNetworkError(e)) {
+				logVerbose(`fetchToken failed with non-network error: ${e}`);
+				return null;
+			}
+			if (retries > 10) {
+				logVerbose(`fetchToken failed with network error, giving up`);
+				throw e;
+			}
+			return retryAfterBackoff('network error');
+		}
+		const { data, error } = result;
+		if (!error) {
+			return data?.token || null;
+		}
+		// The Better Auth client resolves with { data: null, error } on HTTP
+		// error statuses instead of throwing, so HTTP failures never reach the
+		// catch above and must be classified here.
+		if (!isTransientStatus(error.status)) {
+			// A definitive 4xx (401/403 after session expiry or revocation)
+			// means the session is gone — report unauthenticated.
+			logVerbose(`fetchToken failed with status ${error.status}, session is gone`);
+			return null;
+		}
+		if (retries > 10) {
+			logVerbose(`fetchToken failed with status ${error.status}, giving up`);
+			return null;
+		}
+		return retryAfterBackoff(`status ${error.status}`);
+	};
+
+	return fetchWithRetry();
+};


### PR DESCRIPTION
Closes #35

The Better Auth client resolves with `{ data, error }` on HTTP error statuses instead of throwing, so the `isNetworkError` classification in `fetchTokenBrowser` never saw HTTP failures: any status, including a transient 502 while the server restarts during a deploy, fell through `data?.token || null` and was reported to the Convex `AuthenticationManager` as a definitive sign-out, with no recovery until a full reload.

This inspects the resolved `error` instead. 401/403 and other definitive 4xx still return `null` (session expired or revoked), while 5xx, 408, 429 and errors without a status are retried with the existing backoff, exactly like thrown network errors. After the retry budget is exhausted, persistent HTTP errors return `null` (previous end state, but only after ~8.5s of persistent failure) and persistent network errors keep throwing the original error. The helper moves to `fetch-token.ts`, which has no SvelteKit imports, so the retry behavior is now covered by real unit tests instead of logic mirrors: first-try success, definitive 4xx short-circuits, 5xx/408/429 recovery, retry exhaustion, and the preserved network-error paths.

`pnpm run test:unit` (51 passing), `pnpm run check` (0 errors) and `pnpm run lint` pass. Changeset included (patch).
